### PR TITLE
 remove set_amounts from initialization

### DIFF
--- a/app/controllers/commons_controller.rb
+++ b/app/controllers/commons_controller.rb
@@ -117,7 +117,7 @@ class CommonsController < ApplicationController
   # Calculates the amounts totals
   def amounts
     @common = Invoice.new(amounts_params) # TODO: test
-
+    @common.set_amounts # they may have changed in the form
     respond_to do |format|
       format.js
       format.json


### PR DESCRIPTION
This is my proposal

instead of a `taxes` dict inside the model, a dynamic method. we only call it once in the app (in the `_amounts` partial).

keep `set_amounts` separated, and with the meaning of "save totals to db'  that it currently has

as you can see, only one extra `set_amounts` (in the `commons` controller), and it replaces the call in the initialization event, so on that regard we're good