### PR TITLE
Use time zone aware functions

### DIFF
--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -65,7 +65,7 @@ class InvoicesController < CommonsController
   # as values. Uses the same parameters as search.
   def chart_data
     date_from = (params[:q].nil? or params[:q][:issue_date_gteq].empty?) ? 30.days.ago.to_date : Date.parse(params[:q][:issue_date_gteq])
-    date_to = (params[:q].nil? or params[:q][:issue_date_lteq].empty?) ? Date.today : Date.parse(params[:q][:issue_date_lteq])
+    date_to = (params[:q].nil? or params[:q][:issue_date_lteq].empty?) ? Date.current : Date.parse(params[:q][:issue_date_lteq])
 
     scope = @search.result(distinct: true)
     scope = scope.tagged_with(params[:tags].split(/\s*,\s*/)) if params[:tags].present?

--- a/app/controllers/recurring_invoices_controller.rb
+++ b/app/controllers/recurring_invoices_controller.rb
@@ -29,7 +29,7 @@ class RecurringInvoicesController < CommonsController
   # as values
   def chart_data
     # date_from = (params[:q].nil? or params[:q][:issue_date_gteq].empty?) ? 30.days.ago.to_date : Date.parse(params[:q][:issue_date_gteq])
-    # date_to = (params[:q].nil? or params[:q][:issue_date_lteq].empty?) ? Date.today : Date.parse(params[:q][:issue_date_lteq])
+    # date_to = (params[:q].nil? or params[:q][:issue_date_lteq].empty?) ? Date.current : Date.parse(params[:q][:issue_date_lteq])
 
     # scope = @search.result(distinct: true)
     # scope = scope.tagged_with(params[:tags].split(/\s*,\s*/)) if params[:tags].present?

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -24,9 +24,9 @@ class Invoice < Common
     when :paid
       where(draft: false, paid: true)
     when :pending
-      where(draft: false, paid: false).where("due_date >= ?", Date.today)
+      where(draft: false, paid: false).where("due_date >= ?", Date.current)
     when :overdue
-      where(draft: false, paid: false).where("due_date < ?", Date.today)
+      where(draft: false, paid: false).where("due_date < ?", Date.current)
     end
   }
 
@@ -77,7 +77,7 @@ public
     elsif paid
       :paid
     elsif due_date
-      if due_date > Date.today
+      if due_date > Date.current
         :pending
       else
         :overdue
@@ -109,7 +109,7 @@ public
     if unpaid_amount > 0 and not paid
       payment = Payment.create(
           invoice_id: self.id,
-          date: Date.today,
+          date: Date.current,
           amount: unpaid_amount)
       self.save
     end

--- a/app/models/recurring_invoice.rb
+++ b/app/models/recurring_invoice.rb
@@ -59,14 +59,14 @@ class RecurringInvoice < Common
 
     generated_invoices = []
 
-    while next_date <= [Date.today, finishing_date.blank? ? Date.today + 1 : finishing_date].min and
+    while next_date <= [Date.current, finishing_date.blank? ? Date.current + 1 : finishing_date].min and
         (max_occurrences.nil? or occurrences < max_occurrences) do
       inv = self.becomes(Invoice).deep_clone include: { items: :taxes}, except: [:period, :period_type, :starting_date, :finishing_date, :max_occurrences]
 
       inv.recurring_invoice_id = self.id
       inv.status = 'Open'
       inv.issue_date = next_date
-      inv.due_date = Date.today + days_to_due.days if days_to_due
+      inv.due_date = Date.current + days_to_due.days if days_to_due
 
       inv.items.each do |item|
         item.description.sub! "$(issue_date)", inv.issue_date.strftime('%Y-%m-%d')
@@ -118,7 +118,7 @@ class RecurringInvoice < Common
           : actual.starting_date
 
       # is it within range?
-      if next_date > Date.today or !next_date.in? (actual.starting_date...ending_date)
+      if next_date > Date.current or !next_date.in? (actual.starting_date...ending_date)
         next
       end
 

--- a/app/views/invoices/_form.html.haml
+++ b/app/views/invoices/_form.html.haml
@@ -26,11 +26,11 @@
       .col-xs-12.col-sm-4
         .form-group
           = f.label :issue_date
-          = f.date_field :issue_date,  is_new ? { class: 'form-control', value: Date.today() } : { class: 'form-control' }
+          = f.date_field :issue_date,  is_new ? { class: 'form-control', value: Date.current() } : { class: 'form-control' }
       .col-xs-12.col-sm-4
         .form-group
           = f.label :due_date
-          = f.date_field :due_date,  is_new ? { class: 'form-control', value: Date.today() + @days_to_due.days} : { class: 'form-control' }
+          = f.date_field :due_date,  is_new ? { class: 'form-control', value: Date.current() + @days_to_due.days} : { class: 'form-control' }
 
     - if @invoice.new_record? or @invoice.draft
       .checkbox

--- a/lib/tasks/migration.rake
+++ b/lib/tasks/migration.rake
@@ -90,7 +90,7 @@ namespace :siwapp do
     client.query("ALTER TABLE payment ADD created_at datetime")
     client.query("ALTER TABLE payment ADD updated_at datetime")
     client.query("ALTER TABLE payment ADD deleted_at datetime DEFAULT NULL")
-    current_date = DateTime.now.strftime('%Y/%m/%d %H:%M:%S')
+    current_date = DateTime.current.strftime('%Y/%m/%d %H:%M:%S')
     client.query("UPDATE payment SET created_at = '" << current_date << "', updated_at = '" << current_date << "'")
     client.query("ALTER TABLE payment CHANGE created_at created_at datetime NOT NULL")
     client.query("ALTER TABLE payment CHANGE updated_at updated_at datetime NOT NULL")
@@ -156,7 +156,7 @@ namespace :siwapp do
     client.query("ALTER TABLE `tagging` ADD INDEX `index_taggings_on_taggable_id_and_taggable_type_and_context` (`taggable_id`, `taggable_type`, `context`)")
     client.query("RENAME TABLE `tagging` TO `taggings`")
 
-    client.query("UPDATE `taggings` SET `taggable_type` = 'Common', `context` = 'tags', `created_at` = '" << DateTime.now.strftime('%Y/%m/%d %H:%M:%S') << "'")
+    client.query("UPDATE `taggings` SET `taggable_type` = 'Common', `context` = 'tags', `created_at` = '" << DateTime.current.strftime('%Y/%m/%d %H:%M:%S') << "'")
 
     # Update taggings_count
 

--- a/spec/factories/common_factory.rb
+++ b/spec/factories/common_factory.rb
@@ -32,12 +32,12 @@ FactoryGirl.define do
       end
 
       factory :invoice, class: Invoice do
-        issue_date Date.today - 1
-        due_date Date.today + 30
+        issue_date Date.current - 1
+        due_date Date.current + 30
         after(:create) do |invoice|
           # Add some payments
-          create(:payment, invoice: invoice, date: Date.today, amount: 100)
-          create(:payment, invoice: invoice, date: Date.today + 1, amount: 25.77)
+          create(:payment, invoice: invoice, date: Date.current, amount: 100)
+          create(:payment, invoice: invoice, date: Date.current + 1, amount: 25.77)
 
           # super weird thing. iterating through invoice.items or invoice.payments
           # BEFORE the create_list calls, makes the newly created children not to
@@ -50,10 +50,10 @@ FactoryGirl.define do
       end
 
       factory :invoice_unpaid, class: Invoice do
-        issue_date Date.today - 1
-        due_date Date.today + 30
+        issue_date Date.current - 1
+        due_date Date.current + 30
         after(:create) do |i|
-          create(:payment, invoice: i, date: Date.today, amount: 100)
+          create(:payment, invoice: i, date: Date.current, amount: 100)
           i.reload
           # unpaid: 25.77
           i.save
@@ -61,8 +61,8 @@ FactoryGirl.define do
       end
 
       factory :recurring_invoice, class: RecurringInvoice do
-        starting_date Date.today
-        finishing_date Date.today + 7  # 1 week later
+        starting_date Date.current
+        finishing_date Date.current + 7  # 1 week later
         period 1
         period_type "days"
         max_occurrences 5
@@ -73,8 +73,8 @@ FactoryGirl.define do
     factory :common_random do
       factory :invoice_random, class: Invoice do
         draft {rand > 0.5}
-        issue_date Date.today - 1
-        due_date Date.today + 30
+        issue_date Date.current - 1
+        due_date Date.current + 30
 
         customer { Customer.all.sample }
         name { customer.name }
@@ -113,8 +113,8 @@ FactoryGirl.define do
         series { Series.all.sample }
 
         # Set random start (past/present) and finish (present/future) dates
-        starting_date { Date.today >> rand(-8..1) }
-        finishing_date { Date.today >> rand(1..12) }
+        starting_date { Date.current >> rand(-8..1) }
+        finishing_date { Date.current >> rand(1..12) }
 
         period { rand(1..10) }
         period_type {['days', 'months', 'years'].sample }

--- a/spec/factories/payment_factory.rb
+++ b/spec/factories/payment_factory.rb
@@ -1,11 +1,11 @@
 FactoryGirl.define do
   factory :payment do
-    date Date.today
+    date Date.current
     amount 10
   end
 
   factory :payment_random, class: Payment do
-    date Date.today
+    date Date.current
     amount { rand(1..10) }
     notes do
       pay_method = ['visa', 'mastercard', 'american express'].sample

--- a/spec/features/creating_invoices_spec.rb
+++ b/spec/features/creating_invoices_spec.rb
@@ -14,7 +14,7 @@ feature 'Creating Invoices' do
 
     fill_in 'Name', with: 'Test Customer'
     fill_in 'Email', with: 'pepe@abc.com'
-    fill_in 'Issue date', with: Date.today
+    fill_in 'Issue date', with: Date.current
 
     click_on 'Save'
     expect(page).to have_content('Invoice was successfully created.')

--- a/spec/features/editing_invoices_spec.rb
+++ b/spec/features/editing_invoices_spec.rb
@@ -12,7 +12,7 @@ feature 'Editing Invoices' do
   scenario 'Updating an Invoice', :js => true, driver: :webkit do
     fill_in 'Name', with: 'Different Name'
     fill_in 'Email', with: 'different.name@test.com'
-    fill_in 'Due date', with: Date.today + 30
+    fill_in 'Due date', with: Date.current + 30
     click_on 'Save'
     expect(page).to have_content("Invoice was successfully updated")
   end
@@ -68,7 +68,7 @@ feature 'Editing Invoices' do
       # default amount: what's left to pay. rounded with precision of 2
       expect(find('input[name*="amount"]').value.to_f).to eq 25.77
       # default date: today
-      expect(find('input[name*="date"]').value).to eq Date.today.iso8601
+      expect(find('input[name*="date"]').value).to eq Date.current.iso8601
     end
 
     # click over "remove payment"

--- a/spec/features/editing_recurring_invoices_spec.rb
+++ b/spec/features/editing_recurring_invoices_spec.rb
@@ -14,7 +14,7 @@ feature "Editing Recurring Invoices" do
 
   scenario "Updating a recurring invoice with invalid attributes is bad", :js => true, driver: :webkit do
     fill_in "Name", with: ""
-    fill_in "Starting date", with: Date.today
+    fill_in "Starting date", with: Date.current
     fill_in "Finishing date", with: Date.yesterday
     click_on "Save"
     expect(page).to have_content("Name can't be blank")

--- a/spec/features/execute_pending_invoices.rb
+++ b/spec/features/execute_pending_invoices.rb
@@ -12,11 +12,11 @@ feature 'Execute Pending Invoices' do
 
   scenario 'can generate pending invoices' do
     # There is no Invoice for today
-    expect(page).not.to have_content(Date.today.to_s)
+    expect(page).not.to have_content(Date.current.to_s)
     visit 'recurring_invoices/'
     click_link 'Build Pending Invoices'
     # Now there should be 1 Invoice for today
-    expect(page).to have_content(Date.today.to_s)
+    expect(page).to have_content(Date.current.to_s)
     expect(page).to have_content('New Invoice')
 
     #invoice = RecurringInvoice.where(name: 'Test Customer').first

--- a/spec/models/recurring_invoice_spec.rb
+++ b/spec/models/recurring_invoice_spec.rb
@@ -52,14 +52,14 @@ RSpec.describe RecurringInvoice, :type => :model do
   end
 
   it "generates invoices according to max_occurrences" do
-    expect(FactoryGirl.build(:recurring_invoice, starting_date: Date.today << 1).generate_pending_invoices.count).to eq 5
+    expect(FactoryGirl.build(:recurring_invoice, starting_date: Date.current << 1).generate_pending_invoices.count).to eq 5
   end
 
   it "generates invoices according to finishing_date" do
-    expect(FactoryGirl.build(:recurring_invoice, starting_date: Date.today - 7, max_occurrences: nil).generate_pending_invoices.count).to eq 8
+    expect(FactoryGirl.build(:recurring_invoice, starting_date: Date.current - 7, max_occurrences: nil).generate_pending_invoices.count).to eq 8
   end
 
   it "generates invoices with items taxed as described in recurring invoice" do
-    expect(FactoryGirl.create(:recurring_invoice, starting_date: Date.today - 1).generate_pending_invoices[0].tax_amount).to eq 2.466
+    expect(FactoryGirl.create(:recurring_invoice, starting_date: Date.current - 1).generate_pending_invoices[0].tax_amount).to eq 2.466
   end
 end

--- a/spec/requests/api/v1/api_v1_payments_spec.rb
+++ b/spec/requests/api/v1/api_v1_payments_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe "Api::V1::Payments", type: :request do
       payment = {
         'payment'=> {
           'notes' => 'new notes',
-          'date' => Date.today.strftime('%Y-%m-%d'),
+          'date' => Date.current.strftime('%Y-%m-%d'),
           'amount' => 33.3
           }
       }
@@ -66,7 +66,7 @@ RSpec.describe "Api::V1::Payments", type: :request do
       # notes modified
       expect(json['notes']).to eql 'modified NOTES'
       # date not
-      expect(json['date']).to eql Date.today.strftime('%Y-%m-%d')
+      expect(json['date']).to eql Date.current.strftime('%Y-%m-%d')
       # db, too
       expect(Payment.find(json['id']).notes).to eql 'modified NOTES'
     end


### PR DESCRIPTION
Spec failure due to time functions being unaware of time zones.

### RSpec output
```
$ rspec
I, [2016-08-12T05:07:13.546317 #80099]  INFO -- : Celluloid 0.17.3 is running in BACKPORTED mode. [ http://git.io/vJf3J ]
Running via Spring preloader in process 80101
E, [2016-08-12T05:07:24.590972 #80101] ERROR -- : Couldn't cleanly terminate all actors in 10 seconds!
...............F......................................................................

Failures:

  1) Editing Invoices Adding a payments to an Invoice
     Failure/Error: expect(find('input[name*="date"]').value).to eq Date.today.iso8601

       expected: "2016-08-12"
            got: "2016-08-11"

       (compared using ==)
     # ./spec/features/editing_invoices_spec.rb:71:in `block (3 levels) in <top (required)>'
     # /Users/alexcruice/.gem/ruby/2.2.0/gems/capybara-2.7.1/lib/capybara/session.rb:291:in `within'
     # /Users/alexcruice/.gem/ruby/2.2.0/gems/capybara-2.7.1/lib/capybara/dsl.rb:52:in `block (2 levels) in <module:DSL>'
     # ./spec/features/editing_invoices_spec.rb:67:in `block (2 levels) in <top (required)>'

Finished in 35.46 seconds (files took 12.78 seconds to load)
86 examples, 1 failure

Failed examples:

rspec ./spec/features/editing_invoices_spec.rb:56 # Editing Invoices Adding a payments to an Invoice
```

Simple search and replace:
- `Date.current` instead of `Date.today`
- `DateTime.current` instead of `DateTime.now`
- `Time.current` instead of `Time.now` (no occurrences)