### PR TITLE
  smtp settings tests and minor adjustments in smtp settings form

### DIFF
--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -30,7 +30,7 @@ class SettingsController < ApplicationController
       redirect_to settings_smtp_path, notice: "SMTP settings successfully saved"
     else
       flash.now[:alert] = "SMTP settings couldn't be saved"
-      render 'smtp_settings/edit'
+      render 'settings/smtp'
     end
   end
 

--- a/app/models/smtp_settings.rb
+++ b/app/models/smtp_settings.rb
@@ -3,6 +3,11 @@ class SmtpSettings
 
   attr_accessor :host, :port, :domain, :user, :password, :authentication, :enable_starttls_auto, :email_body, :email_subject
 
+  validates :port, numericality: {only_integer: true, greater_than: 0}, allow_blank: true
+  validates :domain, format: {with: /\A((?:[-a-z0-9]+\.)+[a-z]{2,})\z/, message: 'bad format'}, allow_blank: true
+  validate :host_is_legal
+
+
   def save_settings
     if valid?
       [:host, :port, :domain, :user, :password, :authentication, :enable_starttls_auto, :email_body, :email_subject].each do |key|
@@ -17,6 +22,21 @@ class SmtpSettings
     [:host, :port, :domain, :user, :password, :authentication, :enable_starttls_auto, :email_body, :email_subject].each do |key|
       send "#{key}=", "#{attributes[key] || Settings[key]}"
     end
+  end
+
+  private
+
+  # host can be either domain-lik or ip-like
+  def host_is_legal
+    if host.blank?
+      return
+    end
+    if /[a-z]/i.match host # alphanumeric
+      test = /\A((?:[-a-z0-9]+\.)+[a-z]{2,})\z/.match host
+    else # ip address
+      test = /^(?:(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])$/.match host
+    end
+    errors.add(:host, "bad format") unless test
   end
 
 end

--- a/app/views/settings/smtp.html.haml
+++ b/app/views/settings/smtp.html.haml
@@ -9,7 +9,7 @@
             = pluralize @smtp_settings.errors.count, "error"
             prohibited these settings from being saved:
           %ul
-            - @global_settings.errors.full_messages.each do |message|
+            - @smtp_settings.errors.full_messages.each do |message|
               %li= message
       %fieldset
         %legend Server

--- a/spec/features/editing_settings_spec.rb
+++ b/spec/features/editing_settings_spec.rb
@@ -1,30 +1,70 @@
 require 'rails_helper'
 
-feature 'Editing Global Settings' do
+feature 'Editing Settings' do
   before do
     Rails.cache.clear # settings are cached.
     visit "/settings/global"
   end
 
-  scenario 'Edit global settings', :js => true, driver: :webkit do
-    fill_in 'Company Name', with: 'NEW Company Name'
-    fill_in 'Company Email', with: 'bad@company.com'
-    select 'USD', from: 'global_settings_currency'
-    click_on 'Save'
-    expect(page).to have_content("Global settings successfully saved")
-    expect(Settings[:currency]).to eql 'usd'
-    expect(Settings[:company_email]).to eql 'bad@company.com'
+  feature 'Global settings editing' do
+
+    before do
+      visit '/settings/global'
+    end
+
+    scenario 'Edit global settings', :js => true, driver: :webkit do
+      fill_in 'Company Name', with: 'NEW Company Name'
+      fill_in 'Company Email', with: 'bad@company.com'
+      select 'USD', from: 'global_settings_currency'
+      click_on 'Save'
+      expect(page).to have_content("Global settings successfully saved")
+      expect(Settings[:currency]).to eql 'usd'
+      expect(Settings[:company_email]).to eql 'bad@company.com'
+    end
+
+    scenario 'Can not update global settings badly', :js => true, driver: :webkit do
+      fill_in 'Days to due', with: ''
+      fill_in 'Company Email', with: 'bad@email.c'
+      click_on 'Save'
+      expect(page).to have_content("Company email bad format")
+      expect(page).to have_content("Days to due is not a number")
+      expect(page).to have_content(' Global settings could not be saved')
+      # nothing saved
+      expect(Settings[:days_to_due]).to eql 0 # the default setting
+      expect(Settings[:company_email]).to be nil # no saved
+    end
+
   end
 
-  scenario 'Can not update badly', :js => true, driver: :webkit do
-    fill_in 'Days to due', with: ''
-    fill_in 'Company Email', with: 'bad@email.c'
-    click_on 'Save'
-    expect(page).to have_content("Company email bad format")
-    expect(page).to have_content("Days to due is not a number")
-    expect(page).to have_content(' Global settings could not be saved')
-    # nothing saved
-    expect(Settings[:days_to_due]).to eql 0 # the default setting
-    expect(Settings[:company_email]).to be nil # no saved
+  feature 'SMTP settings editing' do
+
+    before do
+      visit '/settings/smtp'
+    end
+
+    scenario 'Edit smtp settings', :js => true, driver: :webkit do
+      fill_in 'Host', with: '127.0.0.1'
+      select 'CRAM md5', from: 'smtp_settings_authentication'
+      click_on 'Save'
+      expect(page).to have_content("SMTP settings successfully saved")
+      expect(Settings[:authentication]).to eql 'cram_md5'
+      expect(Settings[:host]).to eql '127.0.0.1'
+    end
+
+    scenario 'Can not update smtp settings badly', :js => true, driver: :webkit do
+      fill_in 'Host', with: 'badomain'
+      fill_in 'Port', with: '0'
+      click_on 'Save'
+      expect(page).to have_content("Host bad format")
+      expect(page).to have_content("Port must be greater than 0")
+      expect(page).to have_content("SMTP settings couldn't be saved")
+      # nothing saved
+      expect(Settings[:host]).to be nil # not saved
+      expect(Settings[:port]).to be nil # not saved
+    end
+
   end
+
+
+
 end


### PR DESCRIPTION
added smtp settings validation

  - host can be either ip address or alphanumeric
  - port must be greater than 0
  - domain

all three can be blank

also, minor fixes in smtp template

also, added some basic testing for smtp settings editing