### PR TITLE
 #137 allow customer-filtered invoices listing

### DIFF
--- a/app/assets/javascripts/tables.coffee
+++ b/app/assets/javascripts/tables.coffee
@@ -70,6 +70,10 @@ jQuery(document).ready ($) ->
       e.preventDefault()
       window.document.location = $(this).data("href")
 
+    # let a's do their job
+    .on 'click', 'tr[data-href] > td > a', (e) ->
+      e.stopPropagation()
+
     # but avoid redirecting when clicking on a row-selection cell
     .on 'click', 'tr[data-href] > [data-role|="select"]', (e) ->
       e.stopPropagation()

--- a/app/controllers/commons_controller.rb
+++ b/app/controllers/commons_controller.rb
@@ -9,9 +9,16 @@ class CommonsController < ApplicationController
   before_action :set_extra_stuff, only: [:new, :create, :edit, :update]
 
   # GET /commons
+  # GET /customers/:customer_id/commons --> filter by customer
   def index
     # TODO: check https://github.com/activerecord-hackery/ransack/issues/164
     results = @search.result(distinct: true)
+    # filter by customer
+    if params[:customer_id]
+      results = results.where customer_id: params[:customer_id]
+      @customer = Customer.find params[:customer_id]
+      @search_url = send "customer_#{@type.underscore.downcase.pluralize}_path", params[:customer_id]
+    end
     results = results.tagged_with(params[:tags].split(/\s*,\s*/)) if params[:tags].present?
     @gross = results.sum :gross_amount
     @net = results.sum :net_amount

--- a/app/views/customers/index.html.haml
+++ b/app/views/customers/index.html.haml
@@ -11,7 +11,9 @@
       %tbody{data: {role: 'infinite-content'}}
         - @customers.each_with_index do |customer, i|
           %tr{data: {href: edit_customer_path(customer), itemid: customer.id, page_start: i.zero?, page: @customers.current_page}}
-            %td.no-wrap= customer.name
+            %td.no-wrap
+              = customer.name
+              = link_to '(See invoices)', customer_invoices_path(customer.id)
             %td.no-wrap= customer.identification
             %td.text-right= customer.due.round 2
             %td.text-right= customer.total.round 2

--- a/app/views/invoices/index.html.haml
+++ b/app/views/invoices/index.html.haml
@@ -1,5 +1,10 @@
 .section-hd
-  %h1 Invoices
+  %h1
+    Invoices
+    - if @customer
+      for
+      = @customer
+
   %button#js-section-info-button.btn.dropdown-toggle.section-hd__action{type: "button", data: {toggle: "collapse", target: "#js-section-info"}}= display_money @gross
 
 #js-section-info.section-summary.collapse

--- a/app/views/recurring_invoices/index.html.haml
+++ b/app/views/recurring_invoices/index.html.haml
@@ -1,5 +1,8 @@
 .section-hd
   %h1 Recurring Invoices
+  - if @customer
+    for
+    =@customer
   %button#js-section-info-button.btn.dropdown-toggle.section-hd__action{type: "button", data: {toggle: "collapse", target: "#js-section-info"}}= display_money @gross
 
 #js-section-info.section-summary.collapse

--- a/app/views/shared/_searchform.html.haml
+++ b/app/views/shared/_searchform.html.haml
@@ -1,4 +1,5 @@
-= search_form_for @search, html: {class: "collapse nav navbar-nav navbar-toggleable-lg siwapp-search-form", id: "js-search-form"} do |f|
+= search_form_for @search, url: @search_url, html: {class: "collapse nav navbar-nav navbar-toggleable-lg siwapp-search-form", id: "js-search-form"} do |f|
+
   .input-group.siwapp-input-search
     - if @search_filters
       .input-group-btn

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,8 @@ Rails.application.routes.draw do
 
   resources :customers do
     get 'autocomplete', on: :collection
+    resources :invoices, only: [:index]
+    resources :recurring_invoices, only: [:index]
   end
 
   post 'templates/set_default', to: 'templates#set_default'


### PR DESCRIPTION
@peillis, please read this:

  - I've added a new entrypoint: `/customers/:customer_id/invoices`, that entry point should list invoices filtered by `customer_id`
  - The point of that is to allow the user, once he's at the customer's invoices page, to do extra filtering, keeping all the times the basic filter of `customer_id`. I strikes to me as useful. If you want to see a customer's invoices, you may want to find a particular one or filter by some extra criteria, without loosing the "invoices for customer" view.
  - In that sense, I think it's better to have a specific entry point, instead of carrying along some hidden `customer_id` param, also because by simply looking at the url you're aware you're on a "customer filtered" invoices page.
  - I've added to the title "Invoices for Acme Corp." when this entry point is used , to make it more clear.
  - Haven't made added tests yet, waiting for your confirmation.