### PR TITLE
  use the first available template is default is not defined. fixes #149

### DIFF
--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -1,7 +1,8 @@
 class InvoicesController < CommonsController
   # Gets the template to display invoices
   def get_template
-    if template = @invoice.template or template = Template.find_by(default: true)
+    if template = @invoice.template or template = Template.find_by(default: true) \
+        or template = Template.first
       @template_url = "/invoices/template/#{template.id}/invoice/#{@invoice.id}"
     else
       @template_url = ""


### PR DESCRIPTION
@peillis,

the "blank template" page occurs when there's neither a default template or a invoice's own template, even if there is a template on the databse. (not marked as default, of course)

For the time being, I've made that the system use the first found template as a last resource, but maybe we could also show some "no template defined" message when there's no template in the database.