### PR TITLE
  add active field to customers. autocomplete only search active. add…

### DIFF
--- a/app/controllers/customers_controller.rb
+++ b/app/controllers/customers_controller.rb
@@ -7,6 +7,7 @@ class CustomersController < ApplicationController
   def index
     @search = Customer.ransack(params[:q])
     @search.sorts = 'id desc' if @search.sorts.empty?
+    @search_filters = true
     @customers = @search.result(distinct: true)
       .paginate(page: params[:page], per_page: 20)
 
@@ -78,7 +79,7 @@ class CustomersController < ApplicationController
   # GET /customers/autocomplete.json
   # View to get the customer autocomplete feature editing invoices.
   def autocomplete
-    @customers = Customer.order(:name).where("name LIKE ?", "%#{params[:term]}%")
+    @customers = Customer.order(:name).where("name LIKE ? and active = ?", "%#{params[:term]}%", true)
     respond_to do |format|
       format.json
     end
@@ -93,6 +94,6 @@ class CustomersController < ApplicationController
     # Never trust parameters from the scary internet, only allow the white list through.
     def customer_params
       params.require(:customer).permit(:name, :identification, :email, :contact_person,
-                                       :invoicing_address, :shipping_address)
+                                       :invoicing_address, :shipping_address, :active)
     end
 end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -1,6 +1,6 @@
 class Customer < ActiveRecord::Base
   include MetaAttributes
-  
+
   acts_as_paranoid
   has_many :invoices
   has_many :estimates
@@ -11,6 +11,11 @@ class Customer < ActiveRecord::Base
   scope :with_terms, ->(terms) {
     return nil if terms.empty?
     where('name LIKE :terms OR email LIKE :terms OR identification LIKE :terms', terms: '%' + terms + '%')
+  }
+
+  scope :only_active, ->(boolean = true) {
+    return nil unless boolean
+    where(active: true)
   }
 
   def total
@@ -55,6 +60,6 @@ private
   end
 
   def self.ransackable_scopes(auth_object = nil)
-    [:with_terms]
+    [:with_terms, :only_active]
   end
 end

--- a/app/views/customers/_form.html.haml
+++ b/app/views/customers/_form.html.haml
@@ -9,6 +9,11 @@
           %li= message
   %p
     = render partial: 'customers/form_fields', locals: {f: f}
+    .row
+      .col-sm-4
+        .form-group
+          = f.label :active, 'Active Customer'
+          = f.check_box :active
 
   %fieldset.m-b-2
     %legend.m-b-1 Meta

--- a/app/views/customers/_searchform__filters.html.haml
+++ b/app/views/customers/_searchform__filters.html.haml
@@ -1,0 +1,9 @@
+.row
+  .col-xs-12.col-md-6
+    .row
+      .col-xs-12.col-sm-6
+        .form-group
+          = f.label :only_active, "Show only active users"
+          = f.check_box :only_active
+
+=# render 'shared/searchform__tagsfield'

--- a/db/migrate/20160915000824_add_active_to_customer.rb
+++ b/db/migrate/20160915000824_add_active_to_customer.rb
@@ -1,0 +1,11 @@
+class AddActiveToCustomer < ActiveRecord::Migration
+  def up
+    add_column :customers, :active, :boolean, default: true
+    Customer.update_all ["active = ?", true]
+  end
+
+  def down
+    remove_column :customers, :active
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160913081503) do
+ActiveRecord::Schema.define(version: 20160915000824) do
 
   create_table "commons", force: :cascade do |t|
     t.integer  "series_id",            limit: 4
@@ -74,6 +74,7 @@ ActiveRecord::Schema.define(version: 20160913081503) do
     t.text     "shipping_address",  limit: 65535
     t.datetime "deleted_at"
     t.text     "meta_attributes",   limit: 65535
+    t.boolean  "active",                          default: true
   end
 
   add_index "customers", ["deleted_at"], name: "index_customers_on_deleted_at", using: :btree


### PR DESCRIPTION
… advanced search for customers. fixes #139

- migration attached
- since now users can be "active" or not, I've added advanced search to the customers. Only a checkbox that states "only active user". There's another issue on adding tags to customers, so advanced search is a must.