### PR TITLE
Recurring invoice model tests

### DIFF
--- a/app/controllers/commons_controller.rb
+++ b/app/controllers/commons_controller.rb
@@ -91,24 +91,29 @@ class CommonsController < ApplicationController
   # POST /commons
   # POST /commons.json
   def create
-    instance = model.new(type_params)
-    set_instance instance
+    set_instance model.new(type_params)
     respond_to do |format|
+
+      if get_instance.customer.nil?
+        get_instance.customer = Customer.find_by(
+          :name => type_params[:name],
+          :identification => type_params[:identification]
+        )
+      end
+
+      if get_instance.customer.nil?
+        get_instance.customer = Customer.new(
+          :name => type_params[:name],
+          :identification => type_params[:identification],
+          :email => type_params[:email],
+          :contact_person => type_params[:contact_person],
+          :invoicing_address => type_params[:invoicing_address],
+          :shipping_address => type_params[:shipping_address]
+        )
+      end
+
       if get_instance.save
-        set_meta instance
-        # if there is no customer associated then create a new one
-        if type_params[:customer_id] == ''
-          customer = Customer.create(
-            :name => type_params[:name],
-            :identification => type_params[:identification],
-            :email => type_params[:email],
-            :contact_person => type_params[:contact_person],
-            :invoicing_address => type_params[:invoicing_address],
-            :shipping_address => type_params[:shipping_address]
-          )
-          get_instance.update(:customer_id => customer.id)
-        end
-        # Redirect to index
+        set_meta get_instance
         format.html { redirect_to sti_path(@type), notice: "#{type_label} was successfully created." }
       else
         flash[:alert] = "#{type_label} has not been created."

--- a/app/models/common.rb
+++ b/app/models/common.rb
@@ -17,10 +17,11 @@ class Common < ActiveRecord::Base
   accepts_nested_attributes_for :items, :reject_if => :all_blank, :allow_destroy => true
 
   # Validations
+  validate :valid_customer_identification
+  validates :series, presence: true
   validates :email,
     format: {with: /\A([\w+\-].?)+@[a-z\d\-]+(\.[a-z]+)*\.[a-z]+\z/i,
              message: "Only valid emails"}, allow_blank: true
-  validates :series, presence: true
 
   # Events
   before_save :set_amounts
@@ -105,6 +106,14 @@ protected
   # Declare scopes for search
   def self.ransackable_scopes(auth_object = nil)
     [:with_terms]
+  end
+
+private
+
+  def valid_customer_identification
+    unless name? or identification?
+      errors.add :base, "Customer name or identification is required."
+    end
   end
 
 end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -9,7 +9,7 @@ class Customer < ActiveRecord::Base
   has_many :recurring_invoices
 
   # Validation
-  validates :name, presence: true
+  validate :valid_customer_identification
 
   # Behaviors
   acts_as_taggable
@@ -81,6 +81,12 @@ private
 
   def self.ransackable_scopes(auth_object = nil)
     [:with_terms, :only_active]
+  end
+
+  def valid_customer_identification
+    unless name? or identification?
+      errors.add :base, "Name or identification is required."
+    end
   end
 
 end

--- a/app/models/recurring_invoice.rb
+++ b/app/models/recurring_invoice.rb
@@ -95,7 +95,7 @@ class RecurringInvoice < Common
     return if starting_date.blank? || finishing_date.blank?
 
     if starting_date > finishing_date
-      errors.add(:finishing_time, "The end date must be greater than the start date.")
+      errors.add(:finishing_date, "The end date must be greater than the start date.")
     end
   end
 

--- a/app/models/recurring_invoice.rb
+++ b/app/models/recurring_invoice.rb
@@ -7,7 +7,6 @@ class RecurringInvoice < Common
   has_many :invoices
 
   # Validation
-  validates :name, presence: true
   validates :starting_date, presence: true
   validates :period_type, presence: true
   validates :period, presence: true,
@@ -96,7 +95,7 @@ class RecurringInvoice < Common
     return if starting_date.blank? || finishing_date.blank?
 
     if starting_date > finishing_date
-      errors.add(:finishing_time, "Finishing Date must be after Starting Date")
+      errors.add(:finishing_time, "The end date must be greater than the start date.")
     end
   end
 

--- a/app/views/invoices/_form.html.haml
+++ b/app/views/invoices/_form.html.haml
@@ -18,30 +18,38 @@
     %legend.m-b-1 Invoice details
 
     .row
-      .col-xs-12.col-sm-4
-        .form-group
-          = f.label :series
-          = f.collection_select :series_id, @series, :id, :to_s, is_new ? { selected: @default_series_id} : {}, {multiple: false, class: 'form-control c-select'}
-      .col-xs-12.col-sm-4
-        .form-group
-          = f.label :number
-          = f.text_field :number, {class: 'form-control'}
-      .col-xs-12.col-sm-4
-        .form-group
-          = f.label :issue_date
-          = f.date_field :issue_date,  is_new ? { class: 'form-control', value: Date.current() } : { class: 'form-control' }
-      .col-xs-12.col-sm-4
-        .form-group
-          = f.label :due_date
-          = f.date_field :due_date,  is_new ? { class: 'form-control', value: Date.current() + @days_to_due.days} : { class: 'form-control' }
-      .col-xs-12.col-sm-4
-        .form-group
-          = f.label :email_template_id
-          = f.collection_select :email_template_id, @templates, :id, :to_s, {include_blank: "Select template for e-mail"}, {multiple: false, class: 'form-control c-select'}
-      .col-xs-12.col-sm-4
-        .form-group
-          = f.label :print_template_id
-          = f.collection_select :print_template_id, @templates, :id, :to_s, {include_blank: "Select template to print."}, {multiple: false, class: 'form-control c-select'}
+      .col-xs-12.col-lg-8
+        .row
+          .col-xs-12.col-sm-6
+            .form-group
+              = f.label :series
+              = f.collection_select :series_id, @series, :id, :to_s, is_new ? { selected: @default_series_id} : {}, {multiple: false, class: 'form-control c-select'}
+          .col-xs-12.col-sm-6
+            .form-group
+              = f.label :number
+              = f.text_field :number, {class: 'form-control'}
+    .row
+      .col-xs-12.col-lg-8
+        .row
+          .col-xs-12.col-sm-6
+            .form-group
+              = f.label :issue_date
+              = f.date_field :issue_date,  is_new ? { class: 'form-control', value: Date.current() } : { class: 'form-control' }
+          .col-xs-12.col-sm-6
+            .form-group
+              = f.label :due_date
+              = f.date_field :due_date,  is_new ? { class: 'form-control', value: Date.current() + @days_to_due.days} : { class: 'form-control' }
+    .row
+      .col-xs-12.col-lg-8
+        .row
+          .col-xs-12.col-sm-6
+            .form-group
+              = f.label :email_template_id
+              = f.collection_select :email_template_id, @templates, :id, :to_s, {include_blank: "Select template for e-mail"}, {multiple: false, class: 'form-control c-select'}
+          .col-xs-12.col-sm-6
+            .form-group
+              = f.label :print_template_id
+              = f.collection_select :print_template_id, @templates, :id, :to_s, {include_blank: "Select template to print."}, {multiple: false, class: 'form-control c-select'}
 
     = render partial: 'shared/item_form', locals: {f: f, items: :items, invoice: @invoice, is_new: is_new}
 

--- a/spec/features/creating_customers_spec.rb
+++ b/spec/features/creating_customers_spec.rb
@@ -22,8 +22,8 @@ feature 'Creating Customer' do
   scenario 'can not create a Customer without name', :js => true, driver: :webkit do
     fill_in 'Name', with: ''
     click_on 'Save'
-    expect(page).to have_content("Name can't be blank")
-    expect(page).to have_content('error prohibited this customer from being saved')
+    expect(page).to have_content("Name or identification is required.")
+    expect(page).to have_content('1 error prohibited this customer from being saved:')
   end
 
 end

--- a/spec/features/creating_invoices_spec.rb
+++ b/spec/features/creating_invoices_spec.rb
@@ -17,12 +17,13 @@ feature 'Creating Invoices' do
     fill_in 'Issue date', with: Date.current
 
     click_on 'Save'
+
     expect(page).to have_content('Invoice was successfully created.')
-    invoice = Invoice.where(name: 'Test Customer').first
     expect(page.current_path).to eql invoices_path
 
     # Chech that customer is created
-    customer = Customer.where(name: 'Test Customer').first
+    customer = Customer.find_by(name: 'Test Customer')
+    expect(customer).not_to be nil
     expect(customer.email).to eq('pepe@abc.com')
   end
 

--- a/spec/features/creating_recurring_invoices_spec.rb
+++ b/spec/features/creating_recurring_invoices_spec.rb
@@ -34,7 +34,7 @@ feature 'Creating Recurring Invoices' do
 
     click_on 'Save'
     expect(page).to have_content("Recurring Invoice has not been created.")
-    expect(page).to have_content("Name can't be blank")
+    expect(page).to have_content("Customer name or identification is required.")
   end
 
 

--- a/spec/features/editing_customers_spec.rb
+++ b/spec/features/editing_customers_spec.rb
@@ -17,8 +17,8 @@ feature 'Editing Customer' do
   scenario 'can not update badly', :js => true, driver: :webkit do
     fill_in 'Name', with: ''
     click_on 'Save'
-    expect(page).to have_content("Name can't be blank")
-    expect(page).to have_content('error prohibited this customer from being saved')
+    expect(page).to have_content("Name or identification is required.")
+    expect(page).to have_content('1 error prohibited this customer from being saved:')
   end
 
 end

--- a/spec/features/editing_recurring_invoices_spec.rb
+++ b/spec/features/editing_recurring_invoices_spec.rb
@@ -17,7 +17,7 @@ feature "Editing Recurring Invoices" do
     fill_in "Starting date", with: Date.current
     fill_in "Finishing date", with: Date.yesterday
     click_on "Save"
-    expect(page).to have_content("Name can't be blank")
-    expect(page).to have_content("Finishing Date must be after Starting Date")
+    expect(page).to have_content("Customer name or identification is required.")
+    expect(page).to have_content("The end date must be greater than the start date.")
   end
 end

--- a/spec/models/common_spec.rb
+++ b/spec/models/common_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
-require 'siwapp_tests_helper'
 
 RSpec.describe Common, :type => :model do
 
@@ -9,23 +8,31 @@ RSpec.describe Common, :type => :model do
     Rails.cache.delete("rails_settings_cached:currency")
   end
 
+  def build_common(**kwargs)
+    kwargs[:series] = Series.new(value: "A") unless kwargs.has_key? :series
+
+    common = Common.new(name: "A Customer", identification: "123456789Z", **kwargs)
+    common.set_amounts
+    common
+  end
+
   def new_common
     tax1 = Tax.new(value: 10)
     tax2 = Tax.new(value: 40)
     item1 = Item.new(quantity: 1, unitary_cost: 0.09, taxes: [tax1])
     item2 = Item.new(quantity: 1, unitary_cost: 0.09, taxes: [tax1, tax2])
 
-    build_common_as(Common, items: [item1, item2])
+    build_common(items: [item1, item2])
   end
 
   it "is not valid without a series" do
-    c = build_common_as(Common, series: nil)
+    c = build_common(series: nil)
     expect(c).not_to be_valid
     expect(c.errors.messages.has_key? :series).to be true
   end
 
   it "is not valid with bad e-mails" do
-    c = build_common_as(Common, email: "paquito")
+    c = build_common(email: "paquito")
 
     expect(c).not_to be_valid
     expect(c.errors.messages.length).to eq 1

--- a/spec/models/common_spec.rb
+++ b/spec/models/common_spec.rb
@@ -9,9 +9,11 @@ RSpec.describe Common, :type => :model do
   end
 
   def build_common(**kwargs)
+    kwargs[:name] = "A Customer" unless kwargs.has_key? :name
+    kwargs[:identification] = "123456789Z" unless kwargs.has_key? :identification
     kwargs[:series] = Series.new(value: "A") unless kwargs.has_key? :series
 
-    common = Common.new(name: "A Customer", identification: "123456789Z", **kwargs)
+    common = Common.new(**kwargs)
     common.set_amounts
     common
   end
@@ -29,6 +31,21 @@ RSpec.describe Common, :type => :model do
     c = build_common(series: nil)
     expect(c).not_to be_valid
     expect(c.errors.messages.has_key? :series).to be true
+  end
+
+  it "is not valid with at least a name or an identification" do
+    c = build_common(name: nil, identification: nil)
+    expect(c).not_to be_valid
+  end
+
+  it "is valid with at least a name" do
+    c = build_common(identification: nil)
+    expect(c).to be_valid
+  end
+
+  it "is valid with at least an identification" do
+    c = build_common(name: nil)
+    expect(c).to be_valid
   end
 
   it "is not valid with bad e-mails" do

--- a/spec/models/common_spec.rb
+++ b/spec/models/common_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'siwapp_tests_helper'
 
 RSpec.describe Common, :type => :model do
 
@@ -14,21 +15,26 @@ RSpec.describe Common, :type => :model do
     item1 = Item.new(quantity: 1, unitary_cost: 0.09, taxes: [tax1])
     item2 = Item.new(quantity: 1, unitary_cost: 0.09, taxes: [tax1, tax2])
 
-    Common.new(series: Series.new, items: [item1, item2])
+    build_common_as(Common, items: [item1, item2])
   end
 
   it "is not valid without a series" do
-    c = Common.new
+    c = build_common_as(Common, series: nil)
     expect(c).not_to be_valid
     expect(c.errors.messages.has_key? :series).to be true
   end
 
   it "is not valid with bad e-mails" do
-    c = Common.new(series: Series.new)
-    c.email = "paquito"
+    c = build_common_as(Common, email: "paquito")
+
     expect(c).not_to be_valid
+    expect(c.errors.messages.length).to eq 1
+    expect(c.errors.messages.has_key? :email).to be true
+
     c.email = "paquito@example"
+
     expect(c).not_to be_valid
+    expect(c.errors.messages.length).to eq 1
     expect(c.errors.messages.has_key? :email).to be true
   end
 

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -1,14 +1,11 @@
 require 'rails_helper'
+require 'siwapp_tests_helper'
 
 RSpec.describe Invoice, :type => :model do
 
   def build_invoice(**kwargs)
-    kwargs[:series] = Series.new(value: "A") unless kwargs.has_key? :series
     kwargs[:issue_date] = Date.current() unless kwargs.has_key? :issue_date
-
-    invoice = Invoice.new(**kwargs)
-    invoice.set_amounts
-    invoice
+    build_common_as(Invoice, **kwargs)
   end
 
   #

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -1,11 +1,14 @@
 require 'rails_helper'
-require 'siwapp_tests_helper'
 
 RSpec.describe Invoice, :type => :model do
 
   def build_invoice(**kwargs)
     kwargs[:issue_date] = Date.current() unless kwargs.has_key? :issue_date
-    build_common_as(Invoice, **kwargs)
+    kwargs[:series] = Series.new(value: "A") unless kwargs.has_key? :series
+
+    invoice = Invoice.new(name: "A Customer", identification: "123456789Z", **kwargs)
+    invoice.set_amounts
+    invoice
   end
 
   #

--- a/spec/models/recurring_invoice_spec.rb
+++ b/spec/models/recurring_invoice_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
-require 'siwapp_tests_helper'
 
 RSpec.describe RecurringInvoice, :type => :model do
 
@@ -7,7 +6,11 @@ RSpec.describe RecurringInvoice, :type => :model do
     kwargs[:starting_date] = Date.current() unless kwargs.has_key? :starting_date
     kwargs[:period_type] = 'month' unless kwargs.has_key? :period_type
     kwargs[:period] = 1 unless kwargs.has_key? :period
-    build_common_as(RecurringInvoice, **kwargs)
+    kwargs[:series] = Series.new(value: "A") unless kwargs.has_key? :series
+
+    recurring_invoice = RecurringInvoice.new(name: "A Customer", identification: "123456789Z", **kwargs)
+    recurring_invoice.set_amounts
+    recurring_invoice
   end
 
   before do

--- a/spec/siwapp_tests_helper.rb
+++ b/spec/siwapp_tests_helper.rb
@@ -1,9 +1,0 @@
-def build_common_as(model, **kwargs)
-  kwargs[:name] = "A Customer" unless kwargs.has_key? :name
-  kwargs[:identification] = "123456789Z" unless kwargs.has_key? :identification
-  kwargs[:series] = Series.new(value: "A") unless kwargs.has_key? :series
-
-  common = model.new(**kwargs)
-  common.set_amounts
-  common
-end

--- a/spec/siwapp_tests_helper.rb
+++ b/spec/siwapp_tests_helper.rb
@@ -1,0 +1,9 @@
+def build_common_as(model, **kwargs)
+  kwargs[:name] = "A Customer" unless kwargs.has_key? :name
+  kwargs[:identification] = "123456789Z" unless kwargs.has_key? :identification
+  kwargs[:series] = Series.new(value: "A") unless kwargs.has_key? :series
+
+  common = model.new(**kwargs)
+  common.set_amounts
+  common
+end


### PR DESCRIPTION
I've added common validation for required customer details:

- Removed customer name requirement in `RecurringInvoice`
- Added customer name or identification requirement in `Common` so it also applies to the `Invoice` model.

I tried different ways of validating the presence of a customer because _you need someone to invoice to_ (@peillis dixit) but finally not applied it because it added a new layer of complexity both in code and in tests.

`commons_controller` actually adds a new customer if none was selected so... we can test that in functional tests.

<del>I think there's a case that is not handled: you don't select a customer from the suggestions but, instead, you write the same name and identification that other customer has. That produces an integrity error due to the unique index for both fields present in the `Customer` model.</del>

<del>I'm going to investigate this to be sure...</del>

Solved in this PR, now the controller (silently) assigns the invoice to the existing customer.