### PR TITLE
Fixes #138

### DIFF
--- a/app/assets/javascripts/tags.coffee
+++ b/app/assets/javascripts/tags.coffee
@@ -1,5 +1,5 @@
 jQuery(document).ready ($) ->
-  tagging_fields = $ '[data-role="tagging"]'
-  tagging_fields.select2
+  $('[data-role="tagging"]').select2
     tags: true,
     tokenSeparators: [',']
+    closeOnSelect: false


### PR DESCRIPTION
The Select2 library displays all tags by default. I've configured it so it doesn't close when you select one tag so you can continue selecting more than one. It closes when you click anywhere outside the selector. This way it's more comfortable to use.

Signed-off-by: Carlos Escribano <carlosescri@gmail.com>