### PR TITLE
#181 - Number set "auto-magically" for new or draft invoices. Also for existing when series changes.

### DIFF
--- a/app/assets/javascripts/commons.coffee
+++ b/app/assets/javascripts/commons.coffee
@@ -95,16 +95,19 @@ jQuery(document).ready ($) ->
     form = $(this)
     controller_name = form.data('controller')  # REQUIRED!!!
 
-    # If the form is for a new record or is a draft
+    # DOM caching
+    invoice_series = $('#invoice_series_id')
+    invoice_number = $('#invoice_number')
+
+    getNextSeriesNumber = ->
+      $.getJSON Routes.next_number_series_path(invoice_series.val()), (data) ->
+        invoice_number.val(data.value)
+
     if form.data('new') is true
+      # If the form is for a new record or a draft
+
       # DOM caching
       invoice_draft = $('#invoice_draft')
-      invoice_series = $('#invoice_series_id')
-      invoice_number = $('#invoice_number')
-
-      getNextSeriesNumber = ->
-        $.getJSON Routes.next_number_series_path(invoice_series.val()), (data) ->
-          invoice_number.val(data.value)
 
       # Remove invoice number on submit if is a draft
       form.on 'submit', (e) ->
@@ -123,6 +126,15 @@ jQuery(document).ready ($) ->
       # Update invoice number when series change if not a draft
       invoice_series.on 'change', (e) ->
         unless invoice_draft.is ':checked'
+          getNextSeriesNumber()
+    else
+      invoice_series_id_was = parseInt invoice_series.data('series_id_was'), 10
+      invoice_number_was = invoice_number.data 'number_was'
+
+      invoice_series.on 'change', (e) ->
+        if parseInt(invoice_series.val(), 10) == invoice_series_id_was
+          invoice_number.val invoice_number_was
+        else
           getNextSeriesNumber()
 
     autosize form.find('textarea')

--- a/app/assets/javascripts/commons.coffee
+++ b/app/assets/javascripts/commons.coffee
@@ -88,11 +88,42 @@ jQuery(document).ready ($) ->
   #
   # Invoice-like Forms
   #
+  # TODO(@carlosescri): This is always only one form
 
   # Find forms that behave like an invoice:
   $('form[data-role="invoice"]').each ->
     form = $(this)
     controller_name = form.data('controller')  # REQUIRED!!!
+
+    # If the form is for a new record or is a draft
+    if form.data('new') is true
+      # DOM caching
+      invoice_draft = $('#invoice_draft')
+      invoice_series = $('#invoice_series_id')
+      invoice_number = $('#invoice_number')
+
+      getNextSeriesNumber = ->
+        $.getJSON Routes.next_number_series_path(invoice_series.val()), (data) ->
+          invoice_number.val(data.value)
+
+      # Remove invoice number on submit if is a draft
+      form.on 'submit', (e) ->
+        if invoice_draft.is ':checked'
+          invoice_number.val('')
+
+      # If draft status changes
+      invoice_draft.on 'change', (e) ->
+        if invoice_draft.is ':checked'
+          # Remove invoice number if is a draft
+          invoice_number.val('')
+        else
+          # Get next invoice number in other case
+          getNextSeriesNumber()
+
+      # Update invoice number when series change if not a draft
+      invoice_series.on 'change', (e) ->
+        unless invoice_draft.is ':checked'
+          getNextSeriesNumber()
 
     autosize form.find('textarea')
 

--- a/app/controllers/commons_controller.rb
+++ b/app/controllers/commons_controller.rb
@@ -188,9 +188,11 @@ class CommonsController < ApplicationController
   def set_extra_stuff
     @taxes = Tax.where active: true
     @default_taxes_ids = @taxes.find_all { |t| t.default }.collect{|t| t.id }
+
     @series = Series.where enabled: true
+    @default_series = Series.default_series
+
     @templates = Template.all
-    @default_series_id = @series.find_all { |s| s.default }.collect{|s| s.id}
     default_email_template = Template.find_by(email_default: true)
     default_print_template = Template.find_by(print_default: true)
 

--- a/app/controllers/series_controller.rb
+++ b/app/controllers/series_controller.rb
@@ -1,6 +1,6 @@
 class SeriesController < ApplicationController
   before_action :set_type
-  before_action :set_series, only: [:show, :edit, :update, :destroy]
+  before_action :set_series, only: [:show, :edit, :update, :destroy, :next_number]
 
   # GET /series
   # GET /series.json
@@ -68,6 +68,13 @@ class SeriesController < ApplicationController
 	    flash[:alert] = "Series has invoices and can not be destroyed."
         format.html { redirect_to edit_series_path(@series) }
       end
+    end
+  end
+
+  # GET /series/:id/next_number.json
+  def next_number
+    respond_to do |format|
+      format.json { render json: {value: @series.next_number} }
     end
   end
 

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -24,4 +24,8 @@ class Series < ActiveRecord::Base
       first_number
     end
   end
+
+  def self.default_series
+    self.where(enabled: true, default: true).first
+  end
 end

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -15,4 +15,13 @@ class Series < ActiveRecord::Base
     return value if name.empty?
     name
   end
+
+  def next_number
+    invoice = commons.where(type: Invoice, draft: false).order(:number).last
+    if invoice
+      invoice.number + 1
+    else
+      first_number
+    end
+  end
 end

--- a/app/views/invoices/_form.html.haml
+++ b/app/views/invoices/_form.html.haml
@@ -41,14 +41,14 @@
               - if is_new and @default_series
                 = f.collection_select :series_id, @series, :id, :to_s, {selected: @default_series.id}, {multiple: false, class: 'form-control c-select'}
               - else
-                = f.collection_select :series_id, @series, :id, :to_s, {}, {multiple: false, class: 'form-control c-select'}
+                = f.collection_select :series_id, @series, :id, :to_s, {}, {multiple: false, class: 'form-control c-select', 'data-series_id_was': @invoice.series_id_was}
           .col-xs-12.col-sm-6
             .form-group
               = f.label :number
               - if is_new and @default_series
                 = f.text_field :number, {class: 'form-control', value: @default_series.next_number}
               - else
-                = f.text_field :number, {class: 'form-control'}
+                = f.text_field :number, {class: 'form-control', 'data-number_was': @invoice.number_was}
 
         .row
           .col-xs-12.col-sm-6

--- a/app/views/invoices/_form.html.haml
+++ b/app/views/invoices/_form.html.haml
@@ -38,11 +38,17 @@
           .col-xs-12.col-sm-6
             .form-group
               = f.label :series_id
-              = f.collection_select :series_id, @series, :id, :to_s, is_new ? { selected: @default_series_id} : {}, {multiple: false, class: 'form-control c-select'}
+              - if is_new and @default_series
+                = f.collection_select :series_id, @series, :id, :to_s, {selected: @default_series.id}, {multiple: false, class: 'form-control c-select'}
+              - else
+                = f.collection_select :series_id, @series, :id, :to_s, {}, {multiple: false, class: 'form-control c-select'}
           .col-xs-12.col-sm-6
             .form-group
               = f.label :number
-              = f.text_field :number, {class: 'form-control'}
+              - if is_new and @default_series
+                = f.text_field :number, {class: 'form-control', value: @default_series.next_number}
+              - else
+                = f.text_field :number, {class: 'form-control'}
 
         .row
           .col-xs-12.col-sm-6

--- a/app/views/invoices/_form.html.haml
+++ b/app/views/invoices/_form.html.haml
@@ -1,4 +1,4 @@
-= form_for @invoice, data: {role: 'invoice', controller: controller_name, model: controller_name.classify.underscore}, html: {class: 'invoice'} do |f|
+= form_for @invoice, data: {new: is_new || @invoice.draft_was, role: 'invoice', controller: controller_name, model: controller_name.classify.underscore}, html: {class: 'invoice'} do |f|
 
   - if @invoice.errors.any?
     #error_explanation

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,11 @@ Rails.application.routes.draw do
 
   post 'test' => 'hooks#test'
 
-  resources :taxes, :series, :templates
+  resources :taxes, :templates
+
+  resources :series do
+    get 'next_number', on: :member, defaults: {format: :json}
+  end
 
   get "invoices/amounts"
   get "recurring_invoices/amounts"

--- a/spec/factories/common_factory.rb
+++ b/spec/factories/common_factory.rb
@@ -37,7 +37,7 @@ FactoryGirl.define do
 
       factory :due_invoice do
         transient do
-			first_day Date.current - 30
+          first_day Date.current - 30
         end
         sequence(:issue_date, 0) { |n| first_day + n }
         due_date { issue_date + 1 }

--- a/spec/factories/series_factory.rb
+++ b/spec/factories/series_factory.rb
@@ -12,6 +12,12 @@ FactoryGirl.define do
     end
   end
 
+  factory :b_series, class: Series do
+    name "B- Series"
+    value "B-"
+    first_number 3
+  end
+
   factory :nseries, class: Series do
     sequence(:name, "A")  { |n| "#{n}- Series" }
     sequence(:value, "A") { |n| "#{n}-"        }

--- a/spec/features/invoices/create_spec.rb
+++ b/spec/features/invoices/create_spec.rb
@@ -116,4 +116,26 @@ feature "Invoices:" do
 
     expect(page).to have_content "2 errors"
   end
+
+  scenario "User can't set number for a draft", :js => true, :driver => :webkit do
+    FactoryGirl.create(:series, :default)
+
+    visit new_invoice_path
+
+    fill_in "invoice_name", with: "Another Test Customer"
+    fill_in "invoice_identification", with: "54321"
+    fill_in "invoice_email", with: "another@customer.com"
+    fill_in "invoice_invoicing_address", with: "Fake Address"
+
+    check "invoice_draft"
+    expect(find_field("invoice_number").value).to eq ""
+
+    fill_in "invoice_number", with: "10"
+
+    click_on "Save"
+
+    expect(page.current_path).to eql invoices_path
+    expect(page).to have_content("Invoice was successfully created.")
+    expect(page).to have_content "A-[draft]"
+  end
 end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -51,6 +51,14 @@ RSpec.describe Invoice, :type => :model do
     expect(invoice2.number).to eq invoice1.number
   end
 
+  it "can't have the same number as another invoice from the same series" do
+    invoice1 = build_invoice()
+    expect(invoice1.save).to be true
+
+    invoice2 = build_invoice(series: invoice1.series, number: invoice1.number)
+    expect(invoice2.save).to be false
+  end
+
   #
   # Status
   #

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -15,18 +15,29 @@ RSpec.describe Invoice, :type => :model do
   # Invoice Number
   #
 
-  it "no need for an invoice number if it's a draft" do
-    invoice = build_invoice(draft: true)
+  it "has no invoice number if it's a draft" do
+    invoice = build_invoice(draft: true, number: 1)
     invoice.save
 
     expect(invoice.number).to be nil
   end
 
   it "gets an invoice number after saving if it's not a draft" do
-    invoice = build_invoice()
+    series = Series.new(value: "A", first_number: 5)
+    invoice1 = build_invoice(series: series)
+    invoice1.save
+    invoice2 = build_invoice(series: series)
+    invoice2.save
+
+    expect(invoice1.number).to eq 5
+    expect(invoice2.number).to eq 6
+  end
+
+  it "retains the same number after saving" do
+    invoice = build_invoice(number: 2)
     invoice.save
 
-    expect(invoice.number).to eq 1
+    expect(invoice.number).to eq 2
   end
 
   it "may have the same number as another invoice from a different series" do

--- a/spec/models/series_spec.rb
+++ b/spec/models/series_spec.rb
@@ -21,4 +21,16 @@ RSpec.describe Series, :type => :model do
     expect(series.destroy).to be false
   end
 
+  it "returns the first number as next_number if there's no invoice for this series" do
+    series = Series.new(value: "A", first_number: 2)
+    expect(series.next_number).to eq 2
+  end
+
+  it "properly returns the next number" do
+    series = Series.new(value: "A", first_number: 2)
+    series.commons << Invoice.new(name: "A Customer", issue_date: Date.current)
+    series.save
+    expect(series.next_number).to eq 3
+  end
+
 end

--- a/spec/models/series_spec.rb
+++ b/spec/models/series_spec.rb
@@ -33,4 +33,16 @@ RSpec.describe Series, :type => :model do
     expect(series.next_number).to eq 3
   end
 
+  it "returns the default series properly" do
+    Series.create(value: "A")
+    Series.create(value: "B", default: true)
+
+    expect(Series.default_series).not_to be nil
+    expect(Series.default_series.value).to eq "B"
+  end
+
+  it "returns nil if no default series" do
+    expect(Series.default_series).to be nil
+  end
+
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,7 +16,9 @@
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 
-require './spec/support/helpers' # to access helper methods for rspec
+# Helper methods for RSpec
+require './spec/support/helpers'
+require './spec/support/wait_for_ajax'
 
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate

--- a/spec/support/wait_for_ajax.rb
+++ b/spec/support/wait_for_ajax.rb
@@ -1,0 +1,15 @@
+module WaitForAjax
+  def wait_for_ajax
+    Timeout.timeout(Capybara.default_max_wait_time) do
+      loop until finished_all_ajax_requests?
+    end
+  end
+
+  def finished_all_ajax_requests?
+    page.evaluate_script('jQuery.active').zero?
+  end
+end
+
+RSpec.configure do |config|
+  config.include WaitForAjax, type: :feature
+end


### PR DESCRIPTION
This PR also refactors the way the next invoice number is obtained (moved to `Series` model and changed event on `Invoice` model). Also adds a JSON endpoint to obtain the next number of a series via AJAX. Tests added.

**Please, merge _squashed_.**