### PR TITLE
Increase TLD lenght in email regex

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -9,7 +9,7 @@ import Config
 
 config :siwapp,
   ecto_repos: [Siwapp.Repo],
-  email_regex: ~r/^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4}$/
+  email_regex: ~r/^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,6}$/
 
 # Configures the endpoint
 config :siwapp, SiwappWeb.Endpoint,


### PR DESCRIPTION
Emails with long TLD are failing. E.G.: `.online`