### PR TITLE
Fix string for page title when the invoice has no number

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ env:
 
 jobs:
   test-elixir:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     services:
       postgres:

--- a/lib/siwapp_web/live/invoices_live/edit.ex
+++ b/lib/siwapp_web/live/invoices_live/edit.ex
@@ -171,7 +171,7 @@ defmodule SiwappWeb.InvoicesLive.Edit do
 
     socket
     |> assign(:action, :edit)
-    |> assign(:page_title, invoice.series.code <> "-" <> Integer.to_string(invoice.number))
+    |> assign(:page_title, "#{invoice.series.code}-#{Map.get(invoice, :number)}")
     |> assign(:invoice, invoice)
     |> assign(
       :changeset,


### PR DESCRIPTION
Fix https://github.com/siwapp/siwapp/issues/8

If the invoice has draft status, the invoice has no number.