### PR TITLE
Allow TLD of any length for emails

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -9,7 +9,7 @@ import Config
 
 config :siwapp,
   ecto_repos: [Siwapp.Repo],
-  email_regex: ~r/^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,6}$/
+  email_regex: ~r/^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$/
 
 # Configures the endpoint
 config :siwapp, SiwappWeb.Endpoint,


### PR DESCRIPTION
TLD can be longer than 6 characters, so the validation fails.