### PR TITLE
Assign number if is nill

### DIFF
--- a/lib/siwapp/invoices/invoice.ex
+++ b/lib/siwapp/invoices/invoice.ex
@@ -174,7 +174,9 @@ defmodule Siwapp.Invoices.Invoice do
       get_field(changeset, :draft) ->
         changeset
 
-      !is_nil(get_change(changeset, :series_id)) or is_nil(get_field(changeset, :number)) ->
+      # Next number is assigned when changing serie and no number if provided or draft status is removed
+      (!is_nil(get_change(changeset, :series_id)) and is_nil(get_change(changeset, :number))) or
+          is_nil(get_field(changeset, :number)) ->
         next_number =
           changeset
           |> get_field(:series_id)

--- a/lib/siwapp/invoices/invoice.ex
+++ b/lib/siwapp/invoices/invoice.ex
@@ -174,7 +174,9 @@ defmodule Siwapp.Invoices.Invoice do
       get_field(changeset, :draft) ->
         changeset
 
-      # Next number is assigned when changing serie and no number if provided or draft status is removed
+      # There are two situations when the next number of the series is assigned:
+      #   - when the series_id field is changed and no number is provided
+      #   - when the draft status is removed
       (!is_nil(get_change(changeset, :series_id)) and is_nil(get_change(changeset, :number))) or
           is_nil(get_field(changeset, :number)) ->
         next_number =

--- a/lib/siwapp/invoices/invoice.ex
+++ b/lib/siwapp/invoices/invoice.ex
@@ -174,10 +174,7 @@ defmodule Siwapp.Invoices.Invoice do
       get_field(changeset, :draft) ->
         changeset
 
-      is_nil(get_change(changeset, :series_id)) ->
-        changeset
-
-      is_nil(get_change(changeset, :number)) ->
+      !is_nil(get_change(changeset, :series_id)) or is_nil(get_field(changeset, :number)) ->
         next_number =
           changeset
           |> get_field(:series_id)

--- a/test/siwapp/invoices_test.exs
+++ b/test/siwapp/invoices_test.exs
@@ -262,5 +262,12 @@ defmodule Siwapp.InvoicesTest do
       {:ok, invoice1} = Invoices.update(invoice1, %{series_id: new_series.id})
       assert invoice1.number == 21
     end
+
+    test "updating invoice removing draft status (no number). Number is next of greatest invoice's number in series" do
+      series = series_fixture(%{first_number: 7})
+      invoice1 = invoice_fixture(%{series_id: series.id, draft: true})
+      {:ok, invoice1} = Invoices.update(invoice1, %{draft: false})
+      assert invoice1.number == 7
+    end
   end
 end


### PR DESCRIPTION
Fix https://github.com/siwapp/siwapp/issues/12

With this change, the number is assignd both if the series id is changed or the number is nil.