### PR TITLE
Set queue target in repo options

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -28,8 +28,6 @@ config :siwapp, Siwapp.Repo,
   ssl: true,
   # socket_options: [:inet6],
   url: database_url,
-  pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10"),
-  queue_target: String.to_integer(System.get_env("QUEUE_TARGET") || "2000"),
   database: "siwapp_prod",
   show_sensitive_data_on_connection_error: true
 

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -29,6 +29,7 @@ config :siwapp, Siwapp.Repo,
   # socket_options: [:inet6],
   url: database_url,
   pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10"),
+  queue_target: String.to_integer(System.get_env("QUEUE_TARGET") || "2000"),
   database: "siwapp_prod",
   show_sensitive_data_on_connection_error: true
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -30,6 +30,10 @@ if config_env() == :prod do
     ],
     secret_key_base: secret_key_base
 
+  config :siwapp, Siwapp.Repo,
+    pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10"),
+    queue_target: String.to_integer(System.get_env("QUEUE_TARGET") || "2000")
+
   # ## Using releases
   #
   # If you are doing OTP releases, you need to instruct Phoenix


### PR DESCRIPTION
This parameter can be increased in order to avoid timeouts when connecting to database.