### PR TITLE
Get taxes amounts when viewing invoice

### DIFF
--- a/lib/siwapp/invoice_helper.ex
+++ b/lib/siwapp/invoice_helper.ex
@@ -96,7 +96,7 @@ defmodule Siwapp.InvoiceHelper do
 
   @spec set_taxes_amounts(Ecto.Changeset.t()) :: Ecto.Changeset.t()
   defp set_taxes_amounts(changeset) do
-    if is_nil(get_change(changeset, :items)) do
+    if is_nil(get_field(changeset, :items)) do
       changeset
     else
       total_taxes_amounts =

--- a/lib/siwapp/invoices/item.ex
+++ b/lib/siwapp/invoices/item.ex
@@ -99,7 +99,8 @@ defmodule Siwapp.Invoices.Item do
 
   @spec assoc_taxes(Ecto.Changeset.t(), map()) :: Ecto.Changeset.t()
   defp assoc_taxes(changeset, attrs) do
-    attr_taxes_names = MapSet.new(get(attrs, :taxes) || [], &String.upcase/1)
+    changeset_taxes_names = Enum.map(get_field(changeset, :taxes), fn tax -> String.upcase(tax.name) end)
+    attr_taxes_names = MapSet.new(get(attrs, :taxes) || changeset_taxes_names, &String.upcase/1)
 
     all_taxes = Commons.list_taxes(:cache)
 


### PR DESCRIPTION
When viewing an invoice, the taxes amount calculation was empty.