### PR TITLE
Add idx on items_taxes(item_id)

### DIFF
--- a/priv/repo/migrations/20231004080513_add_idx_itemtaxes_itemid.exs
+++ b/priv/repo/migrations/20231004080513_add_idx_itemtaxes_itemid.exs
@@ -1,5 +1,5 @@
 defmodule Siwapp.Repo.Migrations.AddIdxItemTaxesItemId do
   use Ecto.Migration
 
-  def up, do: execute "CREATE INDEX ON items_taxes(item_id);"
+  def up, do: execute("CREATE INDEX ON items_taxes(item_id);")
 end

--- a/priv/repo/migrations/20231004080513_add_idx_itemtaxes_itemid.exs
+++ b/priv/repo/migrations/20231004080513_add_idx_itemtaxes_itemid.exs
@@ -1,7 +1,5 @@
 defmodule Siwapp.Repo.Migrations.AddIdxItemTaxesItemId do
   use Ecto.Migration
 
-  def up do
-    execute "CREATE INDEX ON items_taxes(item_id);"
-  end
+  def up, do: execute "CREATE INDEX ON items_taxes(item_id);"
 end

--- a/priv/repo/migrations/20231004080513_add_idx_itemtaxes_itemid.exs
+++ b/priv/repo/migrations/20231004080513_add_idx_itemtaxes_itemid.exs
@@ -1,0 +1,7 @@
+defmodule Siwapp.Repo.Migrations.AddIdxItemTaxesItemId do
+  use Ecto.Migration
+
+  def up do
+    execute "CREATE INDEX ON items_taxes(item_id);"
+  end
+end


### PR DESCRIPTION
This query appears quite often in the slow logs of Postgresql: 

```
LOG: duration: 2021.025 ms execute ecto_6194: SELECT t0."id", t0."name", t0."value", t0."enabled", t0."default", i1."item_id"::bigint FROM "taxes" AS t0 INNER JOIN "items_taxes" AS i1 ON t0."id" = i1."tax_id" WHERE (i1."item_id" = ANY($1)) ORDER BY i1."item_id"::bigint
DETAIL: parameters: $1 = '{123456}'
```

We just need to add an index to fix it.

cc/ @Aitor-Corrales @RodrigoMolinaMadrid 