### PR TITLE
Require `key` field for `meta_attributes` search

### DIFF
--- a/lib/siwapp/searches.ex
+++ b/lib/siwapp/searches.ex
@@ -35,6 +35,17 @@ defmodule Siwapp.Searches do
   """
   @spec filters_query(Ecto.Queryable.t(), [{binary, binary}] | map()) :: Ecto.Queryable.t()
   def filters_query(query, params) do
+    {key, params} = Map.pop(params, "key")
+    {value, params} = Map.pop(params, "value")
+
+    params =
+      if not is_nil(key) and not is_nil(value) do
+        # Transform params 'key' and 'value' into a single param 'meta_attribute'
+        Map.put(params, {"meta_attribute", key}, value)
+      else
+        params
+      end
+
     Enum.reduce(params, query, fn {key, value}, acc_query ->
       SearchQuery.filter_by(acc_query, key, value)
     end)

--- a/lib/siwapp/searches.ex
+++ b/lib/siwapp/searches.ex
@@ -34,21 +34,29 @@ defmodule Siwapp.Searches do
   Returns a query for the filter_params
   """
   @spec filters_query(Ecto.Queryable.t(), [{binary, binary}] | map()) :: Ecto.Queryable.t()
+  def filters_query(query, params) when is_list(params) do
+    filters_query(query, Map.new(params))
+  end
+
   def filters_query(query, params) do
+    params
+    |> transform_params()
+    |> Enum.reduce(query, fn {key, value}, acc_query ->
+      SearchQuery.filter_by(acc_query, key, value)
+    end)
+  end
+
+  @spec transform_params(map) :: map
+  defp transform_params(params) do
     {key, params} = Map.pop(params, "key")
     {value, params} = Map.pop(params, "value")
 
-    params =
-      if not is_nil(key) and not is_nil(value) do
-        # Transform params 'key' and 'value' into a single param 'meta_attribute'
-        Map.put(params, {"meta_attribute", key}, value)
-      else
-        params
-      end
-
-    Enum.reduce(params, query, fn {key, value}, acc_query ->
-      SearchQuery.filter_by(acc_query, key, value)
-    end)
+    if not is_nil(key) and not is_nil(value) do
+      # Transform params 'key' and 'value' into a single param 'meta_attribute'
+      Map.put(params, "meta_attribute", {key, value})
+    else
+      params
+    end
   end
 
   @doc """

--- a/lib/siwapp/searches/search.ex
+++ b/lib/siwapp/searches/search.ex
@@ -56,6 +56,7 @@ defmodule Siwapp.Searches.Search do
   end
 
   # When field :value has a value, field :key needs to be set as well
+  @spec maybe_validate_key(Ecto.Changeset.t()) :: Ecto.Changeset.t()
   defp maybe_validate_key(%{changes: %{value: value}} = changeset) when is_binary(value) do
     validate_required(changeset, :key)
   end

--- a/lib/siwapp/searches/search.ex
+++ b/lib/siwapp/searches/search.ex
@@ -52,5 +52,13 @@ defmodule Siwapp.Searches.Search do
     |> cast_embed(:csv_meta_attributes,
       with: &CSVMetaAttributes.changeset/2
     )
+    |> maybe_validate_key()
   end
+
+  # When field :value has a value, field :key needs to be set as well
+  defp maybe_validate_key(%{changes: %{value: value}} = changeset) when is_binary(value) do
+    validate_required(changeset, :key)
+  end
+
+  defp maybe_validate_key(changeset), do: changeset
 end

--- a/lib/siwapp/searches/search_query.ex
+++ b/lib/siwapp/searches/search_query.ex
@@ -10,7 +10,7 @@ defmodule Siwapp.Searches.SearchQuery do
   @doc """
   For each key, one different query
   """
-  @spec filter_by(Ecto.Queryable.t(), binary, binary) :: Ecto.Queryable.t()
+  @spec filter_by(Ecto.Queryable.t(), binary, any) :: Ecto.Queryable.t()
   def filter_by(query, "search_input", value) do
     name_email_or_id(query, value)
   end
@@ -52,7 +52,7 @@ defmodule Siwapp.Searches.SearchQuery do
     type_of_status(query, value)
   end
 
-  def filter_by(query, {"meta_attribute", key}, value) do
+  def filter_by(query, "meta_attribute", {key, value}) do
     where(
       query,
       [],

--- a/lib/siwapp/searches/search_query.ex
+++ b/lib/siwapp/searches/search_query.ex
@@ -52,18 +52,12 @@ defmodule Siwapp.Searches.SearchQuery do
     type_of_status(query, value)
   end
 
-  def filter_by(query, "key", value) do
-    join(query, :inner, [q], m in fragment("jsonb_each_text(?)", q.meta_attributes),
-      on: m.key == ^value
+  def filter_by(query, {"meta_attribute", key}, value) do
+    where(
+      query,
+      [],
+      fragment("meta_attributes->>? = ?", type(^key, :string), type(^value, :string))
     )
-  end
-
-  def filter_by(query, "value", value) do
-    query
-    |> join(:inner, [q], m in fragment("jsonb_each_text(?)", q.meta_attributes),
-      on: m.value == ^value
-    )
-    |> distinct(true)
   end
 
   def filter_by(query, "csv_meta_attributes", _value), do: query

--- a/lib/siwapp_web/live/search_live/search_component.ex
+++ b/lib/siwapp_web/live/search_live/search_component.ex
@@ -24,6 +24,7 @@ defmodule SiwappWeb.SearchLive.SearchComponent do
   @impl Phoenix.LiveComponent
   def handle_event("change", %{"search" => search_params}, socket) do
     changeset = Searches.change(%Search{}, search_params)
+    changeset = %{changeset | action: :validate}
 
     {:noreply, assign(socket, :changeset, changeset)}
   end

--- a/lib/siwapp_web/live/search_live/search_component.ex
+++ b/lib/siwapp_web/live/search_live/search_component.ex
@@ -24,6 +24,7 @@ defmodule SiwappWeb.SearchLive.SearchComponent do
   @impl Phoenix.LiveComponent
   def handle_event("change", %{"search" => search_params}, socket) do
     changeset = Searches.change(%Search{}, search_params)
+    # Without this error tags aren't shown
     changeset = %{changeset | action: :validate}
 
     {:noreply, assign(socket, :changeset, changeset)}

--- a/lib/siwapp_web/live/search_live/search_component.html.heex
+++ b/lib/siwapp_web/live/search_live/search_component.html.heex
@@ -33,9 +33,10 @@
         <div class="buttons is-right">
           <%= link("Export to CSV",
             to: Routes.page_path(@socket, :csv, Map.put(f.params, :view, @view)),
-            class: "button is-info"
+            class: "button is-info",
+            disabled: not @changeset.valid?
           ) %>
-          <%= submit("Search", class: "button is-info", "phx-click": JS.hide(to: "#search-menu")) %>
+          <%= submit("Search", class: "button is-info", disabled: not @changeset.valid?, "phx-click": JS.hide(to: "#search-menu")) %>
         </div>
       </div>
     </div>

--- a/lib/siwapp_web/templates/page/invoice_filters.html.heex
+++ b/lib/siwapp_web/templates/page/invoice_filters.html.heex
@@ -60,7 +60,7 @@
       KEY
     </label>
     <%= text_input(@f, :key, class: "input") %>
-    <%= error_tag @f, :key, style: "margin: 0" %>
+    <%= error_tag @f, :key, style: "margin: 0", phx_feedback_for: "" %>
   </div>
   <div class="column">
     <label class="label">

--- a/lib/siwapp_web/templates/page/invoice_filters.html.heex
+++ b/lib/siwapp_web/templates/page/invoice_filters.html.heex
@@ -60,6 +60,7 @@
       KEY
     </label>
     <%= text_input(@f, :key, class: "input") %>
+    <%= error_tag @f, :key, style: "margin: 0" %>
   </div>
   <div class="column">
     <label class="label">

--- a/lib/siwapp_web/views/error_helpers.ex
+++ b/lib/siwapp_web/views/error_helpers.ex
@@ -8,12 +8,16 @@ defmodule SiwappWeb.ErrorHelpers do
   @doc """
   Generates tag for inlined form input errors.
   """
-  @spec error_tag(Phoenix.HTML.Form.t(), atom) :: list
-  def error_tag(form, field) do
+  @spec error_tag(Phoenix.HTML.Form.t(), atom, Keyword) :: list
+  def error_tag(form, field, attrs \\ []) do
     Enum.map(Keyword.get_values(form.errors, field), fn error ->
-      content_tag(:span, translate_error(error),
-        class: "invalid-feedback",
-        phx_feedback_for: input_name(form, field)
+      content_tag(
+        :span,
+        translate_error(error),
+        Keyword.merge(
+          [class: "invalid-feedback", phx_feedback_for: input_name(form, field)],
+          attrs
+        )
       )
     end)
   end

--- a/lib/siwapp_web/views/error_helpers.ex
+++ b/lib/siwapp_web/views/error_helpers.ex
@@ -8,7 +8,7 @@ defmodule SiwappWeb.ErrorHelpers do
   @doc """
   Generates tag for inlined form input errors.
   """
-  @spec error_tag(Phoenix.HTML.Form.t(), atom, Keyword) :: list
+  @spec error_tag(Phoenix.HTML.Form.t(), atom, Keyword.t()) :: list
   def error_tag(form, field, attrs \\ []) do
     Enum.map(Keyword.get_values(form.errors, field), fn error ->
       content_tag(


### PR DESCRIPTION
![image](https://github.com/siwapp/siwapp/assets/775189/aed996ff-e02b-4ce0-a12a-8e41211d6d15)

This restriction allows Siwapp to build a more efficient SQL query