### PR TITLE
Fix mix siwapp.register task

### DIFF
--- a/lib/mix/tasks/siwapp.register.ex
+++ b/lib/mix/tasks/siwapp.register.ex
@@ -15,7 +15,7 @@ defmodule Mix.Tasks.Siwapp.Register do
 
   @impl Mix.Task
   def run(args) do
-    Mix.Task.run("app.start")
+    Application.ensure_all_started(:siwapp)
 
     validate_args!(args)
 
@@ -30,8 +30,7 @@ defmodule Mix.Tasks.Siwapp.Register do
         :ok
 
       {:error, %Ecto.Changeset{} = changeset} ->
-        IO.puts(changeset.errors)
-        Mix.raise("Sorry. The user hasn't been created.")
+        Mix.raise("Sorry. The user hasn't been created.\n\t#{inspect(changeset.errors)}")
     end
   end
 


### PR DESCRIPTION
There were some problems when using the `siwapp.register` task:

### Fixed

- When the application is running, the line `Mix.Task.run("app.start")`
  fails as the application is already running. Instead of that we use
  `Application.ensure_all_started(:siwapp)` that will return `:ok` if
  the application is running.

- The task parameters may contain errors, and the task will return a
  changeset with the errors. Those errors are stored in a map,
  therefore, it can not be serialized with a `IO.puts/1`. We have
  replaced that with a `inspect/1`
