### PR TITLE
Upgrade GitHub cache action version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
           otp-version: ${{ matrix.otp }}
 
       - name: Retrieve Mix Dependencies Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         id: mix-cache #id to use in retrieve action
         with:
           path: deps
@@ -54,7 +54,7 @@ jobs:
         run: mix test
 
       - name: Retrieve PLT Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: _build/dev
           key: ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-plts-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}


### PR DESCRIPTION
GitHub is closing down the `actions/cache` v2 version. We've updated the version to prevent interruptions in our CI.

### Changed

- Updated the `action/cache` to the latest current version.