### PR TITLE
Allow to fetch customer through invoices

### DIFF
--- a/lib/siwapp_web/resolvers/invoice.ex
+++ b/lib/siwapp_web/resolvers/invoice.ex
@@ -24,7 +24,7 @@ defmodule SiwappWeb.Resolvers.Invoice do
       Invoices.list(
         limit: limit,
         offset: offset,
-        preload: [:items, :payments, :series],
+        preload: [:items, :payments, :series, :customer],
         filters: filters
       )
 

--- a/lib/siwapp_web/schema/invoice_types.ex
+++ b/lib/siwapp_web/schema/invoice_types.ex
@@ -6,6 +6,7 @@ defmodule SiwappWeb.Schema.InvoiceTypes do
   object :invoice do
     field :id, :id
     field :customer_id, :id
+    field :customer, :customer
     field :name, :string
     field :identification, :string
     field :contact_person, :string


### PR DESCRIPTION
There was no way to retrieve the customer info related to an invoice
through the GraphQL API. This commit adds that as a feature.

### Added

- Added the option for fetching customer info when querying invoices
  with the GraphQL API.