### PR TITLE
Return status and reference in API responses

### DIFF
--- a/lib/siwapp/invoices.ex
+++ b/lib/siwapp/invoices.ex
@@ -37,11 +37,15 @@ defmodule Siwapp.Invoices do
   """
   @spec create(map()) :: {:ok, Invoice.t()} | {:error, Ecto.Changeset.t()}
   def create(attrs \\ %{}) do
-    %Invoice{}
-    |> change(attrs)
-    |> InvoiceHelper.maybe_find_customer_or_new()
-    |> Invoice.assign_number()
-    |> Repo.insert()
+    result =
+      %Invoice{}
+      |> change(attrs)
+      |> InvoiceHelper.maybe_find_customer_or_new()
+      |> Invoice.assign_number()
+      |> Repo.insert()
+
+    with {:ok, invoice} <- result,
+      do: {:ok, Repo.preload(invoice, [:payments, :series, :customer])}
   end
 
   @doc """
@@ -49,11 +53,15 @@ defmodule Siwapp.Invoices do
   """
   @spec update(Invoice.t(), map()) :: {:ok, Invoice.t()} | {:error, Ecto.Changeset.t()}
   def update(%Invoice{} = invoice, attrs) do
-    invoice
-    |> change(attrs)
-    |> InvoiceHelper.maybe_find_customer_or_new()
-    |> Invoice.assign_number()
-    |> Repo.update()
+    result =
+      invoice
+      |> change(attrs)
+      |> InvoiceHelper.maybe_find_customer_or_new()
+      |> Invoice.assign_number()
+      |> Repo.update()
+
+    with {:ok, invoice} <- result,
+      do: {:ok, Repo.preload(invoice, [:payments, :series, :customer])}
   end
 
   @doc """

--- a/lib/siwapp/invoices.ex
+++ b/lib/siwapp/invoices.ex
@@ -45,7 +45,7 @@ defmodule Siwapp.Invoices do
       |> Repo.insert()
 
     with {:ok, invoice} <- result,
-      do: {:ok, Repo.preload(invoice, [:payments, :series, :customer])}
+         do: {:ok, Repo.preload(invoice, [:payments, :series, :customer])}
   end
 
   @doc """
@@ -61,7 +61,7 @@ defmodule Siwapp.Invoices do
       |> Repo.update()
 
     with {:ok, invoice} <- result,
-      do: {:ok, Repo.preload(invoice, [:payments, :series, :customer])}
+         do: {:ok, Repo.preload(invoice, [:payments, :series, :customer])}
   end
 
   @doc """

--- a/lib/siwapp_web/resolvers/invoice.ex
+++ b/lib/siwapp_web/resolvers/invoice.ex
@@ -45,7 +45,7 @@ defmodule SiwappWeb.Resolvers.Invoice do
 
     case Invoices.create(args) do
       {:ok, invoice} ->
-        {:ok, set_correct_units(invoice)}
+        {:ok, invoice |> set_correct_units() |> set_status() |> set_reference()}
 
       {:error, changeset} ->
         {:error, message: "Failed!", details: Errors.extract(changeset)}
@@ -63,7 +63,7 @@ defmodule SiwappWeb.Resolvers.Invoice do
     else
       case Invoices.update(invoice, params) do
         {:ok, invoice} ->
-          {:ok, set_correct_units(invoice)}
+          {:ok, invoice |> set_correct_units() |> set_status() |> set_reference()}
 
         {:error, changeset} ->
           {:error, message: "Failed!", details: Errors.extract(changeset)}


### PR DESCRIPTION
We have added the status and reference of invoices for the GraphQL
create and update mutations to keep consistency between this and the
queries for retrieving invoices.

### Added

- Fill status and reference for create and update invoice mutations.
