### PR TITLE
fix: create /app dir and set ownership before switching to non-root user

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,7 +34,9 @@ RUN apt update -qq && \
     rm -f google-chrome-stable_${CHROME_VERSION}_amd64.deb
 
 RUN addgroup --system --gid "$GID" "$GROUP" && \
-    useradd --system --create-home --uid "$UID" --gid "$GROUP" "$USER"
+    useradd --system --create-home --uid "$UID" --gid "$GROUP" "$USER" && \
+    mkdir -p /app && \
+    chown "$UID:$GID" /app
 USER $USER
 
 # Set up the working directory


### PR DESCRIPTION
## Summary

- Creates `/app` directory and sets correct ownership (`UID:GID`) in the same `RUN` step that creates the system user, **before** the `USER` directive switches to the non-root user.

## Why

Docker's `WORKDIR` instruction creates the directory as `root` if it doesn't already exist. When the image switches to the non-root `siwapp` user (via `USER $USER`) before `/app` is created with the right owner, any subsequent write to that directory — including `COPY` and `mix` commands — can fail with permission errors.

By explicitly creating `/app` and `chown`-ing it to the target user **while still running as root**, we guarantee the working directory is writable when the non-root user takes over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)